### PR TITLE
feat(xlsx): add header validation to avoid undefined part names

### DIFF
--- a/slashCommands/Importa_Part_Attributes_Excel_To_DXF/importa_atributos_peca_para_dxf.js
+++ b/slashCommands/Importa_Part_Attributes_Excel_To_DXF/importa_atributos_peca_para_dxf.js
@@ -71,6 +71,25 @@ async function processFiles(folderPath, zipLength, interaction) {
     return notErrors;
   }
 
+  const expectedHeaders = ['PartName', 'Thickness', 'Material', 'Quantity'];
+  const actualHeaders = Object.keys(data[0]);
+
+  const headerIssues = [];
+
+  expectedHeaders.forEach((expected, idx) => {
+    if (actualHeaders[idx] !== expected) {
+      headerIssues.push(`:lady_beetle: A${idx + 1} deve conter "${expected}"`);
+    }
+  });
+
+  if (headerIssues.length > 0) {
+    await interaction.followUp(
+      `<@${interaction.user.id}>, há nomes incorretos nas colunas da planilha:\n\n` +
+      headerIssues.join('\n')
+    );
+    return false;
+  }
+
   for (let i = 0; i < data.length; i++) {
     const row = data[i];
     const partName = row['PartName'];


### PR DESCRIPTION
# Pull Request

---

### Adições

- Validação dos cabeçalhos da planilha;
- Retorno de aviso ao usuário com os nomes corretos exigidos.

---

### Como testar

1. Executar `/importa_atributos_peca_para_dxf`;
2. Anexar `.xlsx` com colunas incorretas;
3. Verificar se o bot retorna aviso com os nomes corretos;
4. Testar novamente com planilha correta;
5. A importação deve continuar funcionando normalmente.

---

Closes #10